### PR TITLE
LIEF versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ember requires Python 3. The ember model was built and the [Jupyter notebook](ht
 ```
 conda env create -f environment.yml -n emberenv
 source activate emberenv
-pip install lief==0.8.3
+pip install lief==0.8.3.post3
 python setup.py install
 ```
 
@@ -51,7 +51,7 @@ If you don't need the extra packages to run the Jupyter notebook, then you can u
 ```
 conda env create -f environment_minimal.yml -n emberenv
 source activate emberenv
-pip install lief==0.8.3
+pip install lief==0.8.3.post3
 python setup.py install
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.8.3
+lief==0.8.3.post3
 tqdm==4.21.0
 numpy==1.14.2
 pandas==0.22.0


### PR DESCRIPTION
lief version 0.8.3 doesn't exist anymore in pip. But 0.8.3.post3 does, and tests show it is compatible with existing EMBER features.

Fixes #7 