### PR TITLE
Pip version

### DIFF
--- a/environment_minimal.yml
+++ b/environment_minimal.yml
@@ -11,7 +11,7 @@ dependencies:
 - openblas=0.2.20=7
 - openssl=1.0.2n=0
 - pandas=0.22.0=py36_0
-- pip=9.0.2=py36_0
+- pip=9.0.3=py36_0
 - python=3.6.4=0
 - python-dateutil=2.7.0=py_0
 - pytz=2018.3=py_0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.8.3.post3
+lief==0.8.3
 tqdm==4.21.0
 numpy==1.14.2
 pandas==0.22.0


### PR DESCRIPTION
Fixes #10. pip 9.0.2 was removed from conda channels because of breaking changes. Tests show that pip 9.0.3 produces the same features.