### PR TITLE
minor patch to setup.py

### DIFF
--- a/ember/__init__.py
+++ b/ember/__init__.py
@@ -132,7 +132,9 @@ def create_metadata(data_dir):
     test_records = [dict(record, **{"subset": "test"}) for record in test_records]
 
     metadf = pd.DataFrame(train_records + test_records)[["sha256", "appeared", "subset", "label"]]
-    metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
+    # metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
+    for sha in metadf[["sha256]]:
+        print(sha)
     return metadf
 
 

--- a/ember/__init__.py
+++ b/ember/__init__.py
@@ -133,7 +133,7 @@ def create_metadata(data_dir):
 
     metadf = pd.DataFrame(train_records + test_records)[["sha256", "appeared", "subset", "label"]]
     # metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
-    for sha in metadf[["sha256]]:
+    for sha in metadf[["sha256"]]:
         print(sha)
     return metadf
 

--- a/ember/__init__.py
+++ b/ember/__init__.py
@@ -132,9 +132,7 @@ def create_metadata(data_dir):
     test_records = [dict(record, **{"subset": "test"}) for record in test_records]
 
     metadf = pd.DataFrame(train_records + test_records)[["sha256", "appeared", "subset", "label"]]
-    # metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
-    for sha in metadf[["sha256"]]:
-        print(sha)
+    metadf.to_csv(os.path.join(data_dir, "metadata.csv"))
     return metadf
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lief==0.8.3
 tqdm==4.21.0
-numpy==1.14.2
-pandas==0.22.0
+numpy>=1.14.2
+pandas>=0.22.0
 lightgbm==2.1.0
-scikit-learn==0.19.1
+scikit-learn>=0.19.1


### PR DESCRIPTION
Function `open` selects the default encoding based on the locale of the environment.

This can cause `setup.py` to fail if this encoding doesn't match the file that `setup.py` reads.

This revision just makes explicit that the encoding for the target file must be UTF-8. Now `setup.py` will succeed even if the locale is not UTF-8.