### PR TITLE
LIEF verified to work with LIEF 0.10.1 (latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Use `pip` to install the `ember` and required files
 pip install git+https://github.com/endgameinc/ember.git
 ```
 
-This provides access to EMBER feature extactionm for example.  However, to use the scripts to train the model, one would instead clone the repository.
+This provides access to EMBER feature extaction for example.  However, to use the scripts to train the model, one would instead clone the repository.
 
 
 ### Install after cloning the EMBER repository

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This paper describes many more details about the dataset: [https://arxiv.org/abs
 
 The [LIEF](https://lief.quarkslab.com/) project is used to extract features from PE files included in the EMBER dataset. Raw features are extracted to JSON format and included in the publicly available dataset. Vectorized features can be produced from these raw features and saved in binary format from which they can be converted to CSV, dataframe, or any other format. This repository makes it easy to generate raw features and/or vectorized features from any PE file. Researchers can implement their own features, or even vectorize the existing features differently from the existing implementations.
 
-The feature calculation is versioned. Feature version 1 is calculated with the LIEF library version 0.8.3. Feature version 2 includes the additional data directory feature, updated ordinal import processing, and is calculated with LIEF library version 0.9.0.
+The feature calculation is versioned. Feature version 1 is calculated with the LIEF library version 0.8.3. Feature version 2 includes the additional data directory feature, updated ordinal import processing, and is calculated with LIEF library version 0.9.0.  We have verified under Windows and Linux that LIEF provides consistent feature representation for version 2 features using LIEF version 0.10.1.
 
 ## Years
 
@@ -29,7 +29,7 @@ Download the data here:
 
 ## Installation
 
-Ember requires Python 3.6 (LIEF is not yet compatible with Python 3.7). Use `pip` or `conda` to install the required packages before installing `ember` itself:
+Use `pip` or `conda` to install the required packages before installing `ember` itself:
 
 ```
 pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ Download the data here:
 
 
 ## Installation
+### Instrall directly from git
+Use `pip` to install the `ember` and required files
 
+```
+pip install git+https://github.com/endgameinc/ember.git
+```
+
+This provides access to EMBER feature extactionm for example.  However, to use the scripts to train the model, one would instead clone the repository.
+
+
+### Install after cloning the EMBER repository
 Use `pip` or `conda` to install the required packages before installing `ember` itself:
 
 ```

--- a/ember/features.py
+++ b/ember/features.py
@@ -490,13 +490,13 @@ class PEFeatureExtractor(object):
         ]
         if feature_version == 1:
             if not lief.__version__.startswith("0.8.3"):
-                print(f"WARNING: EMBER feature version 1 requires lief version 0.8.3-18d5b75")
+                print(f"WARNING: EMBER feature version 1 were computed using lief version 0.8.3-18d5b75")
                 print(f"WARNING:   lief version {lief.__version__} found instead. There may be slight inconsistencies")
                 print(f"WARNING:   in the feature calculations.")
         elif feature_version == 2:
             self.features.append(DataDirectories())
             if not lief.__version__.startswith("0.9.0"):
-                print(f"WARNING: EMBER feature version 2 requires lief version 0.9.0-")
+                print(f"WARNING: EMBER feature version 2 were computed using lief version 0.9.0-")
                 print(f"WARNING:   lief version {lief.__version__} found instead. There may be slight inconsistencies")
                 print(f"WARNING:   in the feature calculations.")
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lief==0.9.0
+lief>=0.9.0
 tqdm>=4.31.0
 numpy>=1.16.3
 pandas>=0.24.2

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -1,4 +1,4 @@
-py-lief==0.9.0
+py-lief>=0.9.0
 tqdm>=4.31.0
 numpy>=1.16.3
 pandas>=0.24.2


### PR DESCRIPTION
Relax strict requirement for LIEF 0.9.0 while **still warning users about possible inconsistencies**.  Testing with LIEF 0.10.1 (latest release) shows the following:

* On Linux and Windows, I found no difference in scores produced by `classifier_binaries.py` when extracting features at test time using LIEF 0.9.0 or 0.10.1.  (The model was trained using 0.9.0.  I tested benign binaries from `C:\Windows\System32\*.exe`.)

* When [comparing 0.9.0 to 0.10.1](https://github.com/lief-project/LIEF/compare/0.9.0...0.10.1), improvements to PE parsing appear to include: authenticode parsing, PE debug directory, handling empty strings.  Other commit message for PE appear to center around modifying PE files.

* By upgrading to 0.10.1, Python 3.7+ now becomes available, as LIEF has built `.whl` packages for new LIEF for new Python releases across platforms.  (The LIEF 0.9.0 release was restricted to older `.egg` files, with no versions for Python versions exceeding 3.6.)

* Using this one fix, one can now install `ember` via
```pip install git+https://github.com/endgameinc/ember.git@update_lief_dependency```
(where the `@update_lief_dependency` branch tag may be removed when this PR is merged)