### PR TITLE
Pin LIEF Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Base image
+FROM mambaorg/micromamba:0.25.1
+
+# Set working directory
+WORKDIR /ember
+
+# Install dependencies
+COPY --chown=$MAMBA_USER:$MAMBA_USER requirements_conda.txt /ember/
+RUN micromamba install -y -n base --channel conda-forge --file requirements_conda.txt && \
+    micromamba clean --all --yes
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+# Copy all files
+COPY --chown=$MAMBA_USER:$MAMBA_USER . /ember
+
+# Install EMBER
+RUN python setup.py install

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This paper describes many more details about the dataset: [https://arxiv.org/abs
 
 The [LIEF](https://lief.quarkslab.com/) project is used to extract features from PE files included in the EMBER dataset. Raw features are extracted to JSON format and included in the publicly available dataset. Vectorized features can be produced from these raw features and saved in binary format from which they can be converted to CSV, dataframe, or any other format. This repository makes it easy to generate raw features and/or vectorized features from any PE file. Researchers can implement their own features, or even vectorize the existing features differently from the existing implementations.
 
-The feature calculation is versioned. Feature version 1 is calculated with the LIEF library version 0.8.3. Feature version 2 includes the additional data directory feature, updated ordinal import processing, and is calculated with LIEF library version 0.9.0.  We have verified under Windows and Linux that LIEF provides consistent feature representation for version 2 features using LIEF version 0.10.1.
+The feature calculation is versioned. Feature version 1 is calculated with the LIEF library version 0.8.3. Feature version 2 includes the additional data directory feature, updated ordinal import processing, and is calculated with LIEF library version 0.9.0.  We have verified under Windows and Linux that LIEF provides consistent feature representation for version 2 features using LIEF version 0.10.1 and that it does not on a Mac.
 
 ## Years
 
@@ -51,6 +51,12 @@ conda config --add channels conda-forge
 conda install --file requirements_conda.txt
 python setup.py install
 ```
+
+### Notes on LIEF versions
+
+LIEF is now pinned to version 0.9.0 in the provided requirements files. This default behavior will allow new users to immediately reproduce EMBER version 2 features. LIEF 0.9.0 will not install on an M1 Mac, though. For those users, a Dockerfile is now included that installs the dependencies using conda.
+
+EMBER will work with more recent releases of LIEF, but keep in mind that models trained on features generated with one version of LIEF will have unpredictable results when evaluating on features generated with another.
 
 ## Scripts
 

--- a/ember/features.py
+++ b/ember/features.py
@@ -164,7 +164,7 @@ class SectionInfo(FeatureType):
         sections = raw_obj['sections']
         general = [
             len(sections),  # total number of sections
-            # number of sections with nonzero size
+            # number of sections with zero size
             sum(1 for s in sections if s['size'] == 0),
             # number of sections with an empty name
             sum(1 for s in sections if s['name'] == ""),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lief>=0.9.0
+lief==0.9.0
 tqdm>=4.31.0
 numpy>=1.16.3
 pandas>=0.24.2

--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -1,4 +1,4 @@
-py-lief>=0.9.0
+py-lief==0.9.0
 tqdm>=4.31.0
 numpy>=1.16.3
 pandas>=0.24.2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ with open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="UTF-8"
     readme = f.read()
 
 version = "0.1.0"
-requires = open("requirements.txt", "r").read().strip().split()
 package_data = {}
 setup(
     name="ember",
@@ -20,5 +19,4 @@ setup(
     long_description=readme,
     packages=["ember"],
     package_data=package_data,
-    install_requires=requires,
     author_email="proth@endgame.com")


### PR DESCRIPTION
- update the requirements files to require LIEF 0.9.0
- remove `requires` clause from `setup.py` so that advanced users can still experiment with more recent versions of LIEF
- add a Dockerfile
- update README with relevant instructions
- update README to show that newer versions of LIEF do not reproduce EMBER features on Macs
- updating a comment to match the actual feature calculation behavior

I believe (re)pinning the version of LIEF will lead to less installation and compatibility issues and make it easier to get started.