### PR TITLE
Bug fix: FeatureHasher’s transform expects a list of list of strings

### DIFF
--- a/ember/features.py
+++ b/ember/features.py
@@ -189,7 +189,7 @@ class SectionInfo(FeatureType):
         section_entropy_hashed = FeatureHasher(50, input_type="pair").transform([section_entropy]).toarray()[0]
         section_vsize = [(s['name'], s['vsize']) for s in sections]
         section_vsize_hashed = FeatureHasher(50, input_type="pair").transform([section_vsize]).toarray()[0]
-        entry_name_hashed = FeatureHasher(50, input_type="string").transform([raw_obj['entry']]).toarray()[0]
+        entry_name_hashed = FeatureHasher(50, input_type="string").transform([[raw_obj['entry']]]).toarray()[0]
         characteristics = [p for s in sections for p in s['props'] if s['name'] == raw_obj['entry']]
         characteristics_hashed = FeatureHasher(50, input_type="string").transform([characteristics]).toarray()[0]
 


### PR DESCRIPTION
A recent version of scikit-learn added a check to the input data of the function "transform" in FeatureHasher. The details are in this pull request: https://github.com/scikit-learn/scikit-learn/pull/25094.

This check fails when transform in invoked by ember on this line (in ember/features.py, line 192):
`entry_name_hashed = FeatureHasher(50, input_type="string").transform([raw_obj['entry']]).toarray()[0]`
because `[raw_obj['entry']]` is a list of strings, not a list of list of strings.

This pull request changes this call to transform by wrapping everything in a list.
I am not sure of the soundness of my fix, so I encourage the reviewer to have a deeper look.