### PR TITLE
Patched np.int, feature hashing problem, and lief errors version

### DIFF
--- a/ember/features.py
+++ b/ember/features.py
@@ -191,7 +191,7 @@ class SectionInfo(FeatureType):
         section_entropy_hashed = FeatureHasher(50, input_type="pair").transform([section_entropy]).toarray()[0]
         section_vsize = [(s['name'], s['vsize']) for s in sections]
         section_vsize_hashed = FeatureHasher(50, input_type="pair").transform([section_vsize]).toarray()[0]
-        entry_name_hashed = FeatureHasher(50, input_type="string").transform([raw_obj['entry']]).toarray()[0]
+        entry_name_hashed = FeatureHasher(50, input_type="string").transform([[raw_obj['entry']]]).toarray()[0]
         characteristics = [p for s in sections for p in s['props'] if s['name'] == raw_obj['entry']]
         characteristics_hashed = FeatureHasher(50, input_type="string").transform([characteristics]).toarray()[0]
 

--- a/ember/features.py
+++ b/ember/features.py
@@ -98,7 +98,7 @@ class ByteEntropyHistogram(FeatureType):
         return Hbin, c
 
     def raw_features(self, bytez, lief_binary):
-        output = np.zeros((16, 16), dtype=np.int)
+        output = np.zeros((16, 16), dtype=int)
         a = np.frombuffer(bytez, dtype=np.uint8)
         if a.shape[0] < self.window:
             Hbin, c = self._entropy_bin_counts(a)

--- a/ember/features.py
+++ b/ember/features.py
@@ -143,7 +143,7 @@ class SectionInfo(FeatureType):
             return {"entry": "", "sections": []}
 
         # properties of entry point, or if invalid, the first executable section
-        not_found_error_class = lief.lief_errors.not_found if not lief.__version__.startswith("0.9.0") else lief.not_found
+        not_found_error_class = RuntimeError if not lief.__version__.startswith("0.9.0") else lief.not_found
         try:
             if int(LIEF_MAJOR) > 0 or (int(LIEF_MAJOR) == 0 and int(LIEF_MINOR) >= 12):
                 section = lief_binary.section_from_rva(lief_binary.entrypoint - lief_binary.imagebase)
@@ -156,8 +156,9 @@ class SectionInfo(FeatureType):
         except not_found_error_class:
             # bad entry point, let's find the first executable section
             entry_section = ""
+            mem_execute_characteristics = lief.PE.SECTION_CHARACTERISTICS.MEM_EXECUTE if lief.__version__.startswith("0.9.0") else lief.PE.Section.CHARACTERISTICS.MEM_EXECUTE
             for s in lief_binary.sections:
-                if lief.PE.SECTION_CHARACTERISTICS.MEM_EXECUTE in s.characteristics_lists:
+                if mem_execute_characteristics in s.characteristics_lists:
                     entry_section = s.name
                     break
 


### PR DESCRIPTION
I fixed three things in this PR:
* now all the NP.INT are INT (so no issues from numpy)
* FeatureHashing was failing for raw_obj['entry'] as it was a single string
* Replaced lief.ERROR with lief.lief_errors.ERROR (and tried to match the same errors, since they have been refaactored)